### PR TITLE
LP staking migration to dexes

### DIFF
--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -79,6 +79,7 @@ def validate_epoch_or_date_arg(ctx, param, value):
 @epoch_or_date_arg
 def lp(indy: float, pkh: tuple[str], outfile: str, epoch_or_date: int | datetime.date):
     """Print or save liquidity pool token staking rewards."""
+    _error_on_lp_moved_to_dex(epoch_or_date)
     if isinstance(epoch_or_date, int):
         rewards = lp_module.get_epoch_rewards_per_staker(epoch_or_date, indy)
     else:
@@ -103,6 +104,8 @@ def lp_apr(indy: float, epoch_or_date: int | datetime.date):
             dexes_sorted = sorted(aprs_by_iasset[iasset].keys(), key=lambda x: x.name)
             for dex in dexes_sorted:
                 click.echo(f"{dex.name}: {aprs_by_iasset[iasset][dex] * 100:.2f}%")
+
+    _error_on_lp_moved_to_dex(epoch_or_date)
 
     if isinstance(epoch_or_date, int):
         epoch = epoch_or_date
@@ -350,3 +353,13 @@ def _error_on_future(epoch_or_date: int | datetime.date):
                 f"{get_snap_str(day)}\n\n"
                 "Plus up to 45 minutes until results appear on the API."
             )
+
+
+def _error_on_lp_moved_to_dex(epoch_or_date: int | datetime.date):
+    if (isinstance(epoch_or_date, int) and epoch_or_date > 421) or (
+        isinstance(epoch_or_date, datetime.date)
+        and epoch_or_date > datetime.date(2023, 7, 4)
+    ):
+        raise click.BadArgumentUsage(
+            "LP reward distribution moved to dexes starting 2023 July 5th."
+        )

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -411,7 +411,7 @@ def _error_on_lp_moved_to_dex(epoch_or_date: int | datetime.date):
 def _sum_lp_rewards(rewards: list[LiquidityPoolReward]) -> dict[LiquidityPool, float]:
     indy_by_lp: dict[LiquidityPool, float] = defaultdict(float)
     for r in rewards:
-        indy_by_lp[r.lp] += r.indy
+        indy_by_lp[r.lp] += round(r.indy, 6)
     return indy_by_lp
 
 

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -423,6 +423,7 @@ def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
         dex_groups[lp.dex].append((lp, indy))
 
     total_indy = sum(summed_rewards.values())
+    print(f"Total: {total_indy:.6f} INDY")
 
     for dex in sorted(dex_groups.keys(), key=lambda x: x.name):
         lp_totals = dex_groups[dex]

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -433,5 +433,5 @@ def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
             percent = (indy / total_indy) * 100
             click.echo(
                 f"- {lp.dex} {lp.iasset}/{lp.other_asset_name}: "
-                f"{indy:.6f} {percent:.1f}%"
+                f"{indy:12.6f} {percent:5.1f}%"
             )

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -422,10 +422,16 @@ def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
     for lp, indy in summed_rewards.items():
         dex_groups[lp.dex].append((lp, indy))
 
+    total_indy = sum(summed_rewards.values())
+
     for dex in sorted(dex_groups.keys(), key=lambda x: x.name):
         lp_totals = dex_groups[dex]
         lp_totals_sorted = sorted(lp_totals, key=lambda x: x[0].iasset.name)
         dex_total = sum(total for _, total in lp_totals_sorted)
         click.echo(f"\n{dex} (Total: {dex_total:.6f}):\n")
         for lp, indy in lp_totals_sorted:
-            click.echo(f"- {lp.dex} {lp.iasset}/{lp.other_asset_name}: {indy:.6f}")
+            percent = (indy / total_indy) * 100
+            click.echo(
+                f"- {lp.dex} {lp.iasset}/{lp.other_asset_name}: "
+                f"{indy:.6f} {percent:.1f}%"
+            )

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -408,10 +408,12 @@ def _error_on_lp_moved_to_dex(epoch_or_date: int | datetime.date):
         )
 
 
-def _sum_lp_rewards(rewards: list[LiquidityPoolReward]) -> dict[LiquidityPool, float]:
+def _sum_lp_rewards(
+    rewards: list[LiquidityPoolReward], rounded: bool = False
+) -> dict[LiquidityPool, float]:
     indy_by_lp: dict[LiquidityPool, float] = defaultdict(float)
     for r in rewards:
-        indy_by_lp[r.lp] += round(r.indy, 6)
+        indy_by_lp[r.lp] += round(r.indy, 6) if rounded else r.indy
     return indy_by_lp
 
 
@@ -423,7 +425,9 @@ def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
         dex_groups[lp.dex].append((lp, indy))
 
     total_indy = sum(summed_rewards.values())
-    print(f"Total: {total_indy:.6f} INDY")
+    click.echo(
+        f"Total: {sum(_sum_lp_rewards(rewards, rounded=True).values()):.6f} INDY"
+    )
 
     for dex in sorted(dex_groups.keys(), key=lambda x: x.name):
         lp_totals = dex_groups[dex]

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -149,7 +149,7 @@ def lp_summary(indy: float, start_date: datetime.datetime, end_date: datetime.da
 
     delta = end - start
     total_days = delta.days + 1
-    click.echo(f"Number of days: {total_days}")
+    click.echo(f"Days: {total_days}")
 
     rewards: list[LiquidityPoolReward] = []
 

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -418,7 +418,7 @@ def _sum_lp_rewards(rewards: list[LiquidityPoolReward]) -> dict[LiquidityPool, f
 def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
     summed_rewards = _sum_lp_rewards(rewards)
 
-    dex_groups = defaultdict(list)
+    dex_groups: dict[Dex, list[tuple[LiquidityPool, float]]] = defaultdict(list)
     for lp, indy in summed_rewards.items():
         dex_groups[lp.dex].append((lp, indy))
 

--- a/indy_rewards/cli.py
+++ b/indy_rewards/cli.py
@@ -427,7 +427,7 @@ def _print_dex_rewards_grouped(rewards: list[LiquidityPoolReward]):
     for dex in sorted(dex_groups.keys(), key=lambda x: x.name):
         lp_totals = dex_groups[dex]
         lp_totals_sorted = sorted(lp_totals, key=lambda x: x[0].iasset.name)
-        dex_total = sum(total for _, total in lp_totals_sorted)
+        dex_total = sum(round(total, 6) for _, total in lp_totals_sorted)
         click.echo(f"\n{dex} (Total: {dex_total:.6f}):\n")
         for lp, indy in lp_totals_sorted:
             percent = (indy / total_indy) * 100

--- a/indy_rewards/lp/__init__.py
+++ b/indy_rewards/lp/__init__.py
@@ -1,2 +1,6 @@
 from .apr import get_epoch_aprs
-from .distribution import get_epoch_rewards_per_staker, get_rewards_per_staker
+from .distribution import (
+    get_epoch_rewards_per_staker,
+    get_pool_rewards,
+    get_rewards_per_staker,
+)

--- a/indy_rewards/lp/distribution.py
+++ b/indy_rewards/lp/distribution.py
@@ -51,6 +51,15 @@ def get_iassets_daily_indy(day: datetime.date, epoch_indy: float) -> list[IAsset
     return [IAssetReward(iasset=k, indy=v, day=day) for k, v in iasset_indy.items()]
 
 
+def get_pool_rewards(
+    day: datetime.date, epoch_indy: float
+) -> list[LiquidityPoolReward]:
+    lp_daily_status = analytics_api.get_lp_status(day)
+    iassets_indy = get_iassets_daily_indy(day, epoch_indy)
+    pool_rewards = distribute_to_liquidity_pools(iassets_indy, lp_daily_status, day)
+    return pool_rewards
+
+
 def distribute_to_accounts(
     day: datetime.date, iassets_daily_rewards: list[IAssetReward]
 ) -> list[IndividualReward]:

--- a/indy_rewards/models.py
+++ b/indy_rewards/models.py
@@ -27,6 +27,9 @@ class IAsset(Enum):
                 return member
         raise ValueError(f"Invalid IAsset: {name}")
 
+    def __str__(self):
+        return self.name
+
     def __repr__(self):
         return f"IAsset({self.name})"
 
@@ -42,6 +45,9 @@ class Dex(Enum):
             if member.name.lower() == name.lower():
                 return member
         raise ValueError(f"No Dex matching '{name}'")
+
+    def __str__(self):
+        return self.name
 
     def __repr__(self):
         return f"Dex({self.name})"

--- a/indy_rewards/summary.py
+++ b/indy_rewards/summary.py
@@ -33,9 +33,11 @@ def get_epoch_all_rewards(
     """
     gov_rewards = gov.get_epoch_rewards_per_staker(epoch, gov_indy)
     sp_rewards = sp.get_epoch_rewards_per_staker(epoch, sp_indy)
-    lp_rewards = lp.get_epoch_rewards_per_staker(epoch, lp_indy)
 
-    all_rewards = sp_rewards + lp_rewards + gov_rewards
+    all_rewards = sp_rewards + gov_rewards
+
+    if epoch < 422:
+        all_rewards += lp.get_epoch_rewards_per_staker(epoch, lp_indy)
 
     return all_rewards
 
@@ -54,7 +56,8 @@ def get_day_all_rewards(
         rewards += gov.get_epoch_rewards_per_staker(epoch, gov_indy_per_epoch)
 
     rewards += sp.get_rewards_per_staker(day, sp_indy_per_epoch)
-    rewards += lp.get_rewards_per_staker(day, lp_indy_per_epoch)
+    if day <= datetime.date(2023, 7, 4):
+        rewards += lp.get_rewards_per_staker(day, lp_indy_per_epoch)
 
     return rewards
 


### PR DESCRIPTION
Updates related to https://app.indigoprotocol.io/governance/polls/19 "(1) Replace LP Token Staking Rewards with DEX Yield Farm Rewards":

- Disable old-style LP results in a backward compatible way.
    - Disable `lp` and `lp-apr` commands.
    - Remove LP rewards from `summary` and `all`.
- New `lp-summary` command, used to determine INDY rewards for each LP (of each dex).