### PR TITLE
Remove duplicate governance account PKH check

### DIFF
--- a/indy_rewards/analytics_api/raw.py
+++ b/indy_rewards/analytics_api/raw.py
@@ -395,6 +395,9 @@ def rewards_staking(snapshot_unix_time: float) -> list[dict]:
     Returns:
         List of dicts, each dict containing a PKH and its reward-eligible INDY balance.
 
+        PKHs are not unique. There are multiple entries with the same PKH if the PKH has
+        multiple on-chain reward-eligible gov staking accounts.
+
         Dict structure:
 
         owner (str): PaymentKeyHash of the owner, in hex.

--- a/indy_rewards/gov.py
+++ b/indy_rewards/gov.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pandas as pd
 
 from . import analytics_api, time_utils
@@ -16,15 +14,10 @@ def get_epoch_rewards_per_staker(
     df = pd.DataFrame(account_indy)
 
     total_staked_indy = df["staked_indy"].sum() / 1e6
+
     df["pkh_indy"] = df.groupby(["owner"])["staked_indy"].transform("sum") / 1e6
     df["pkh_account_count"] = df.groupby(["owner"])["owner"].transform("count")
-
-    if snap_date < datetime.date(2023, 5, 20):
-        df = df.drop_duplicates(subset=["owner"])
-    else:
-        duplicates = df[df.duplicated(subset="owner", keep=False)]
-        if not duplicates.empty:
-            raise Exception("Duplicate 'owner' rows in API response.")
+    df = df.drop_duplicates(subset=["owner"])
 
     df["reward"] = df.apply(
         lambda row: row["pkh_indy"] * epoch_indy / total_staked_indy, axis=1


### PR DESCRIPTION
TL;DR This PR removes a safety measure in the client that was put in place to warn of possible duplicate PKHs from the `/rewards/staking` API endpoint. Now that the API's behavior is verified, this safety measure can be removed.

---

It's possible for a single PKH to have multiple reward-eligible gov staking accounts on-chain. Always has been, by design. I wasn't sure how that's represented in the undocumented API (if at all), whether duplicate PKHs can show up legitimately in the response, if their INDY values will be right or not in that edge case, so I made the client raise an error for duplicate PKHs.

Now it happened on-chain due to deficiencies in the web app (unintended creation of a second hidden gov staking account and failing to handle such an account afterwards). That said, the existence of duplicate accounts is not the problem, problem is the API's complete lack of documentation and the vague response data type and endpoint name.

As it turns out, the API handles multiple gov accounts belonging to the same owner by returning separate entries for each account, with the same `owner` for each, with no errors in `staked_indy` values.

The safety precaution was removed now that the API behavior is confirmed in practice. Code remains otherwise unaltered, it was always compatible.

To test, run `indy-rewards summary 425`. Without this change it raises a "Duplicate 'owner' rows in API response." exception, with this change it runs successfully.

Error was triggered by the fact that in
https://analytics.indigoprotocol.io/api/rewards/staking?timestamp=1690235100, PKH `9d77c4650d9fc15ff9d7591ec7324e12e84a7b588a88586e55113d83` has the below two accounts according to the API, which is true. The `/rewards/staking` API endpoint returns these as separate entries with the same `owner`.

```json
[
    {
        "output_hash": "b5895f08a1d214112e2f4bcc427050cbcdceaa0d814c51bc9dee134c05f0e94d",
        "output_index": 0,
        "owner": "9d77c4650d9fc15ff9d7591ec7324e12e84a7b588a88586e55113d83",
        "staked_indy": 198840064,
        "locked_amount": "{\"23\":[198840064,1690462681000]}",
        "snapshot_ada": 941194
    },
    {
        "output_hash": "43aa24bae08ec2125452ba190cb65af56d0d68fc739a27d66607b15dc5e9e803",
        "output_index": 0,
        "owner": "9d77c4650d9fc15ff9d7591ec7324e12e84a7b588a88586e55113d83",
        "staked_indy": 15274784,
        "locked_amount": "{\"23\":[15274784,1690462681000]}",
        "snapshot_ada": 946265
    }
]
```