### PR TITLE
Change governance distribution

### DIFF
--- a/indy_rewards/config.py
+++ b/indy_rewards/config.py
@@ -5,7 +5,6 @@ from .models import IAsset
 from .time_utils import date_to_epoch
 
 LP_EPOCH_INDY: Final[int] = 4795
-GOV_EPOCH_INDY: Final[int] = 2398
 
 IASSET_LAUNCH_DATES = {
     IAsset.iUSD: datetime.date(2022, 11, 21),  # Epoch 377's first day.

--- a/indy_rewards/sp/distribution.py
+++ b/indy_rewards/sp/distribution.py
@@ -340,3 +340,13 @@ def sp_epoch_emission(epoch: int) -> float:
         return 22431
 
     return 28768
+
+
+def gov_epoch_emission(epoch: int) -> float:
+    if epoch >= 524:
+        return 5315
+
+    if epoch >= 488:
+        return 6046.11
+
+    return 2398


### PR DESCRIPTION
Before epoch 488 distribute 2398 INDY.
488 and after distribute 6046.11 INDY
524 and after distribute 5315 INDY.

This is due to the changes by proposals [#49](https://app.indigoprotocol.io/governance/polls/49) and [#48](https://app.indigoprotocol.io/governance/polls/48)