### PR TITLE
Stability Pool Reward changes based on proposal #55

### DIFF
--- a/indy_rewards/sp/distribution.py
+++ b/indy_rewards/sp/distribution.py
@@ -89,6 +89,13 @@ def get_pool_weights(
             IAsset.from_str("iusd"): (15574 / 22431),
         }
 
+    if day >= datetime.date(2024, 7, 18):
+        return {
+            IAsset.from_str("ibtc"): (1504.89 / 18664.35),
+            IAsset.from_str("ieth"): (2469.29 / 18664.35),
+            IAsset.from_str("iusd"): (14690.17 / 18664.35),
+        }
+
     return get_pool_weights_before_epoch_448(
         saturations, market_caps, day, new_iassets, has_stakers
     )
@@ -338,6 +345,9 @@ def _is_at_least_24h_old(account: dict, snapshot_day: datetime.date) -> bool:
 def sp_epoch_emission(epoch: int) -> float:
     if epoch >= 447:
         return 22431
+
+    if epoch >= 498:
+        return 18664.35
 
     return 28768
 

--- a/indy_rewards/sp/distribution.py
+++ b/indy_rewards/sp/distribution.py
@@ -82,18 +82,18 @@ def get_pool_weights(
     new_iassets: set[IAsset],
     has_stakers: set[IAsset],
 ) -> dict[IAsset, float]:
-    if day >= datetime.date(2023, 11, 6):
-        return {
-            IAsset.from_str("ibtc"): (3668 / 22431),
-            IAsset.from_str("ieth"): (3188 / 22431),
-            IAsset.from_str("iusd"): (15574 / 22431),
-        }
-
     if day >= datetime.date(2024, 7, 18):
         return {
             IAsset.from_str("ibtc"): (1504.89 / 18664.35),
             IAsset.from_str("ieth"): (2469.29 / 18664.35),
             IAsset.from_str("iusd"): (14690.17 / 18664.35),
+        }
+
+    if day >= datetime.date(2023, 11, 6):
+        return {
+            IAsset.from_str("ibtc"): (3668 / 22431),
+            IAsset.from_str("ieth"): (3188 / 22431),
+            IAsset.from_str("iusd"): (15574 / 22431),
         }
 
     return get_pool_weights_before_epoch_448(
@@ -343,11 +343,11 @@ def _is_at_least_24h_old(account: dict, snapshot_day: datetime.date) -> bool:
 
 
 def sp_epoch_emission(epoch: int) -> float:
-    if epoch >= 447:
-        return 22431
-
     if epoch >= 498:
         return 18664.35
+
+    if epoch >= 447:
+        return 22431
 
     return 28768
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click  == 8.*
-pandas == 2.0.*
+pandas == 2.2.*
 requests == 2.*
 python-dotenv == 1.*
 jsonschema == 4.*


### PR DESCRIPTION
The proposal #55 had an error which caused a change in the total INDY distributed per epoch, so we adjusted the SP rewards by adding 9.33 INDY per epoch to each iAsset for SP. The final values were:

iUSD SP: 14690.17 INDY/epoch
iBTC SP: 2469.29 INDY/epoch
iETH SP: 1504.89 INDY/epoch
Total SP Rewards: 18664.35